### PR TITLE
Roll out refresh() pattern to remaining window.location.reload() sites

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -194,7 +194,18 @@ export function MyToggleButton({
 
 **Pattern B — mutation affects other UI on the page (e.g. tags, exclusion status, competition assignment):**
 
-Track only the pending flag with `useState`, then call `window.location.reload()` once the action resolves. A full reload is heavier (loses scroll position / tab selection) but is unconditionally correct and avoids the RSC-cache/scheduler issue entirely. These are infrequent, deliberate actions, not high-frequency interactions.
+Call `refresh()` (`next/cache`) from inside the server action itself, after `revalidatePath(...)`. `refresh()` is architecturally distinct from `router.refresh()` — it doesn't hit the `isPending`-stuck scheduler bug described above. Track only the pending flag with `useState` on the client; the component stays mounted, so explicitly reset whatever local state a full reload used to clear for free (close dialogs, clear create-form fields, reset selects) — see the components under `components/games/`, `components/admin/`, and `components/laserball/` for worked examples.
+
+```tsx
+// actions.ts — "use server"
+import { refresh, revalidatePath } from "next/cache";
+
+export async function myAction(id: string) {
+  await mutate(id);
+  revalidatePath(`/things/${id}`);
+  refresh();
+}
+```
 
 ```tsx
 "use client";
@@ -208,7 +219,7 @@ export function MyActionButton({ action }: { action: () => Promise<void> }) {
     try {
       await action();
     } finally {
-      window.location.reload();
+      setIsPending(false);
     }
   }
 
@@ -220,29 +231,12 @@ export function MyActionButton({ action }: { action: () => Promise<void> }) {
 }
 ```
 
-Server actions should still call `revalidatePath` — it clears the server-side cache so the reloaded page returns fresh data.
-
-**Trial: `refresh()` in place of `window.location.reload()`.** Next.js 16 added `refresh()`
-(`next/cache`), a Server-Actions-only API called from inside the action itself rather than
-from client code — architecturally distinct from `router.refresh()`, so it may not hit the
-same scheduler bug. `GameTagManager.tsx` (`src/app/games/[slug]/actions.ts`'s
-`assignTagAction`/`removeTagAction`) was migrated from full-reload to
-`revalidatePath(...)` + `refresh()`, manually verified in the browser (repeated add/remove
-clicks, no stuck-pending state), and is now being watched in production. If it holds up, this
-becomes the preferred Pattern B implementation and the other ~32 `window.location.reload()`
-sites are candidates to migrate; if it regresses, revert this one site back to
-`window.location.reload()` and treat the hypothesis as disproven.
-
-```tsx
-"use server";
-import { refresh, revalidatePath } from "next/cache";
-
-export async function myAction(id: string) {
-  await mutate(id);
-  revalidatePath(`/things/${id}`);
-  refresh();
-}
-```
+This was trialed on `GameTagManager.tsx` and the team roster admin page before being rolled
+out across the rest of the app (see `docs/TODO.md` git history for the migration list) — watch
+new Pattern B sites in production for a stuck `isPending` the same way. `DeleteEntityButton.tsx`
+(`components/admin/competition/`) is the one deliberate holdout still on
+`window.location.reload()`: it's shared across 7+ admin pages and accepts either calling
+convention, so it can be migrated independently later without another cross-cutting change.
 
 ## Cross-Page Filter State (scope / gameType / center / competition)
 

--- a/apps/web/src/app/admin/api-keys/_components/ApiKeysClient.tsx
+++ b/apps/web/src/app/admin/api-keys/_components/ApiKeysClient.tsx
@@ -60,7 +60,7 @@ export function ApiKeysClient({ keys, createAction, revokeAction }: Props) {
     try {
       await revokeAction(id);
     } finally {
-      window.location.reload();
+      setIsPending(false);
     }
   }
 
@@ -159,7 +159,6 @@ export function ApiKeysClient({ keys, createAction, revokeAction }: Props) {
           if (!open) {
             setNewKey(null);
             setCopied(false);
-            window.location.reload();
           }
         }}
       >
@@ -190,7 +189,6 @@ export function ApiKeysClient({ keys, createAction, revokeAction }: Props) {
               onClick={() => {
                 setNewKey(null);
                 setCopied(false);
-                window.location.reload();
               }}
             >
               Done

--- a/apps/web/src/app/admin/api-keys/actions.ts
+++ b/apps/web/src/app/admin/api-keys/actions.ts
@@ -4,7 +4,7 @@
 "use server";
 
 import { createApiKey, revokeApiKey } from "@lfstats/db";
-import { revalidatePath } from "next/cache";
+import { refresh, revalidatePath } from "next/cache";
 import { requireSuperAdmin } from "@/lib/auth-guards";
 
 // API keys grant write access across every center, so both actions below are
@@ -20,6 +20,7 @@ export async function createApiKeyAction(formData: FormData): Promise<{ plaintex
 
   const { plaintext } = await createApiKey(name, session.user.id);
   revalidatePath("/admin/api-keys");
+  refresh();
   return { plaintext };
 }
 
@@ -27,4 +28,5 @@ export async function revokeApiKeyAction(id: string): Promise<void> {
   await requireSuperAdmin();
   await revokeApiKey(id);
   revalidatePath("/admin/api-keys");
+  refresh();
 }

--- a/apps/web/src/app/admin/centers/actions.ts
+++ b/apps/web/src/app/admin/centers/actions.ts
@@ -5,7 +5,7 @@
 
 import { auth } from "@/auth";
 import { updateCenter } from "@lfstats/db";
-import { revalidatePath } from "next/cache";
+import { refresh, revalidatePath } from "next/cache";
 
 async function requireCenterAdmin(centerId: string) {
   const session = await auth();
@@ -30,4 +30,5 @@ export async function updateCenterAction(id: string, formData: FormData) {
 
   await updateCenter(id, { name, shortName, city, countryName, timezone });
   revalidatePath("/admin/centers", "layout");
+  refresh();
 }

--- a/apps/web/src/app/admin/chomperErrors/actions.ts
+++ b/apps/web/src/app/admin/chomperErrors/actions.ts
@@ -5,7 +5,7 @@
 
 import { auth } from "@/auth";
 import { archiveChomperJob, archiveAllChomperJobs } from "@lfstats/db";
-import { revalidatePath } from "next/cache";
+import { refresh, revalidatePath } from "next/cache";
 
 async function requireAdmin() {
   const session = await auth();
@@ -18,10 +18,12 @@ export async function archiveChomperJobAction(id: string) {
   await requireAdmin();
   await archiveChomperJob(id);
   revalidatePath("/admin/chomperErrors");
+  refresh();
 }
 
 export async function archiveAllChomperJobsAction() {
   await requireAdmin();
   await archiveAllChomperJobs();
   revalidatePath("/admin/chomperErrors");
+  refresh();
 }

--- a/apps/web/src/app/admin/chomperErrors/archive-buttons.tsx
+++ b/apps/web/src/app/admin/chomperErrors/archive-buttons.tsx
@@ -15,7 +15,7 @@ export function ArchiveButton({ id }: { id: string }) {
     try {
       await archiveChomperJobAction(id);
     } finally {
-      window.location.reload();
+      setIsPending(false);
     }
   }
 
@@ -34,7 +34,7 @@ export function ArchiveAllButton() {
     try {
       await archiveAllChomperJobsAction();
     } finally {
-      window.location.reload();
+      setIsPending(false);
     }
   }
 

--- a/apps/web/src/app/admin/competitions/[slug]/rounds/[roundId]/matches/[matchId]/ForfeitButtons.tsx
+++ b/apps/web/src/app/admin/competitions/[slug]/rounds/[roundId]/matches/[matchId]/ForfeitButtons.tsx
@@ -21,7 +21,7 @@ export function ForfeitButtons({ team1Name, team2Name, gameNumber, action }: Pro
     try {
       await action(team, gameNumber);
     } finally {
-      window.location.reload();
+      setIsPending(false);
     }
   }
 

--- a/apps/web/src/app/admin/competitions/[slug]/rounds/[roundId]/matches/[matchId]/actions.ts
+++ b/apps/web/src/app/admin/competitions/[slug]/rounds/[roundId]/matches/[matchId]/actions.ts
@@ -3,7 +3,7 @@
 
 "use server";
 
-import { revalidatePath } from "next/cache";
+import { refresh, revalidatePath } from "next/cache";
 import {
   assignGameToMatch,
   removeGameFromMatch,
@@ -50,6 +50,7 @@ export async function assignGameAction(
     revalidatePath(`/admin/competitions/${slug}/rounds/${match.roundId}/matches/${matchId}`);
     revalidatePath(`/admin/competitions/${slug}/rounds/${match.roundId}`);
   }
+  refresh();
 }
 
 export async function removeGameAction(
@@ -83,6 +84,7 @@ export async function updateMatchTeamsAction(
     revalidatePath(`/admin/competitions/${slug}/rounds/${match.roundId}/matches/${matchId}`);
     revalidatePath(`/admin/competitions/${slug}/rounds/${match.roundId}`);
   }
+  refresh();
 }
 
 export async function updateMatchScheduleAction(
@@ -115,6 +117,7 @@ export async function updateMatchScheduleAction(
     revalidatePath(`/admin/competitions/${slug}/rounds/${match.roundId}/matches/${matchId}`);
     revalidatePath(`/admin/competitions/${slug}/rounds/${match.roundId}`);
   }
+  refresh();
 }
 
 export async function createForfeitAction(
@@ -154,4 +157,5 @@ export async function createForfeitAction(
     revalidatePath(`/admin/competitions/${slug}/rounds/${match.roundId}/matches/${matchId}`);
     revalidatePath(`/admin/competitions/${slug}/rounds/${match.roundId}`);
   }
+  refresh();
 }

--- a/apps/web/src/app/admin/competitions/[slug]/rounds/[roundId]/matches/[matchId]/actions.ts
+++ b/apps/web/src/app/admin/competitions/[slug]/rounds/[roundId]/matches/[matchId]/actions.ts
@@ -66,6 +66,7 @@ export async function removeGameAction(
     revalidatePath(`/admin/competitions/${slug}/rounds/${match.roundId}/matches/${matchId}`);
     revalidatePath(`/admin/competitions/${slug}/rounds/${match.roundId}`);
   }
+  refresh();
 }
 
 export async function updateMatchTeamsAction(

--- a/apps/web/src/app/admin/competitions/[slug]/rounds/actions.ts
+++ b/apps/web/src/app/admin/competitions/[slug]/rounds/actions.ts
@@ -3,7 +3,7 @@
 
 "use server";
 
-import { revalidatePath } from "next/cache";
+import { refresh, revalidatePath } from "next/cache";
 import {
   createCompetitionRound,
   updateCompetitionRound,
@@ -51,6 +51,7 @@ export async function createRoundAction(competitionId: string, formData: FormDat
   const type = formData.get("type") as "pool" | "finals" | "split-pool" | "wildcard";
   await createCompetitionRound({ competitionId, name, roundNumber, type });
   await revalidateRoundsPage(competitionId);
+  refresh();
 }
 
 export async function updateRoundAction(
@@ -64,6 +65,7 @@ export async function updateRoundAction(
   const type = formData.get("type") as "pool" | "finals" | "split-pool" | "wildcard";
   await updateCompetitionRound(roundId, { name, roundNumber, type });
   await revalidateRoundPage(competitionId, roundId);
+  refresh();
 }
 
 export async function deleteRoundAction(competitionId: string, roundId: string): Promise<void> {
@@ -86,6 +88,7 @@ export async function createMatchAction(
   const matchNumber = existing.length > 0 ? Math.max(...existing.map((m) => m.matchNumber)) + 1 : 1;
   await createCompetitionMatch({ competitionId, roundId, matchNumber, team1Id, team2Id, poolId });
   await revalidateRoundPage(competitionId, roundId);
+  refresh();
 }
 
 export async function deleteMatchAction(
@@ -96,6 +99,7 @@ export async function deleteMatchAction(
   await requireAdmin();
   await deleteCompetitionMatch(matchId);
   await revalidateRoundPage(competitionId, roundId);
+  refresh();
 }
 
 export async function generatePoolMatchesAction(
@@ -120,6 +124,7 @@ export async function generatePoolMatchesAction(
     }
   }
   await revalidateRoundPage(competitionId, roundId);
+  refresh();
 }
 
 export async function updateMatchTeamsAction(
@@ -140,6 +145,7 @@ export async function updateMatchTeamsAction(
   }
   await updateCompetitionMatchTeams(matchId, data);
   await revalidateRoundPage(competitionId, roundId);
+  refresh();
 }
 
 export async function reorderMatchesAction(
@@ -177,6 +183,7 @@ export async function generateSplitPoolMatchesAction(
     }
   }
   await revalidateRoundPage(competitionId, roundId);
+  refresh();
 }
 
 export async function createPoolAction(
@@ -188,6 +195,7 @@ export async function createPoolAction(
   const name = formData.get("name") as string;
   await createCompetitionPool({ roundId, name });
   await revalidateRoundPage(competitionId, roundId);
+  refresh();
 }
 
 export async function renamePoolAction(
@@ -200,6 +208,7 @@ export async function renamePoolAction(
   const name = formData.get("name") as string;
   await renameCompetitionPool(poolId, name);
   await revalidateRoundPage(competitionId, roundId);
+  refresh();
 }
 
 export async function deletePoolAction(
@@ -210,6 +219,7 @@ export async function deletePoolAction(
   await requireAdmin();
   await deleteCompetitionPool(poolId);
   await revalidateRoundPage(competitionId, roundId);
+  refresh();
 }
 
 export async function assignTeamToPoolAction(

--- a/apps/web/src/app/admin/competitions/[slug]/rounds/actions.ts
+++ b/apps/web/src/app/admin/competitions/[slug]/rounds/actions.ts
@@ -72,6 +72,7 @@ export async function deleteRoundAction(competitionId: string, roundId: string):
   await requireAdmin();
   await deleteCompetitionRound(roundId);
   await revalidateRoundsPage(competitionId);
+  refresh();
 }
 
 export async function createMatchAction(

--- a/apps/web/src/app/admin/competitions/[slug]/teams/actions.ts
+++ b/apps/web/src/app/admin/competitions/[slug]/teams/actions.ts
@@ -3,7 +3,7 @@
 
 "use server";
 
-import { revalidatePath } from "next/cache";
+import { refresh, revalidatePath } from "next/cache";
 import {
   createCompetitionTeam,
   deleteCompetitionTeam,
@@ -33,6 +33,7 @@ export async function createCompetitionTeamAction(
   await createCompetitionTeam({ competitionId, name, shortName });
   const comp = await getCompetitionById(competitionId);
   if (comp) revalidatePath(`/admin/competitions/${comp.slug}/teams`);
+  refresh();
 }
 
 export async function deleteCompetitionTeamAction(

--- a/apps/web/src/app/admin/competitions/[slug]/teams/actions.ts
+++ b/apps/web/src/app/admin/competitions/[slug]/teams/actions.ts
@@ -44,6 +44,7 @@ export async function deleteCompetitionTeamAction(
   await deleteCompetitionTeam(teamId);
   const comp = await getCompetitionById(competitionId);
   if (comp) revalidatePath(`/admin/competitions/${comp.slug}/teams`);
+  refresh();
 }
 
 export async function addPlayerToTeamAction(
@@ -72,6 +73,7 @@ export async function removePlayerFromTeamAction(
     getCompetitionTeamById(teamId),
   ]);
   if (comp && team) revalidatePath(`/admin/competitions/${comp.slug}/teams/${team.slug}`);
+  refresh();
 }
 
 export async function searchPlayersAction(query: string): Promise<PlayerSearchResult[]> {

--- a/apps/web/src/app/admin/tags/actions.ts
+++ b/apps/web/src/app/admin/tags/actions.ts
@@ -5,7 +5,7 @@
 
 import { auth } from "@/auth";
 import { createTag, updateTag, archiveTag, unarchiveTag, deleteTag, mergeTag } from "@lfstats/db";
-import { revalidatePath } from "next/cache";
+import { refresh, revalidatePath } from "next/cache";
 
 async function requireCenterAdmin(centerId: string) {
   const session = await auth();
@@ -28,6 +28,7 @@ export async function createTagAction(centerId: string, formData: FormData) {
 
   await createTag({ centerId, name, color, description });
   revalidatePath("/admin/tags", "layout");
+  refresh();
 }
 
 export async function updateTagAction(id: string, centerId: string, formData: FormData) {
@@ -39,28 +40,33 @@ export async function updateTagAction(id: string, centerId: string, formData: Fo
 
   await updateTag(id, { name, color, description });
   revalidatePath("/admin/tags", "layout");
+  refresh();
 }
 
 export async function archiveTagAction(id: string, centerId: string) {
   await requireCenterAdmin(centerId);
   await archiveTag(id);
   revalidatePath("/admin/tags", "layout");
+  refresh();
 }
 
 export async function unarchiveTagAction(id: string, centerId: string) {
   await requireCenterAdmin(centerId);
   await unarchiveTag(id);
   revalidatePath("/admin/tags", "layout");
+  refresh();
 }
 
 export async function deleteTagAction(id: string, centerId: string) {
   await requireCenterAdmin(centerId);
   await deleteTag(id);
   revalidatePath("/admin/tags", "layout");
+  refresh();
 }
 
 export async function mergeTagAction(sourceId: string, targetId: string, centerId: string) {
   await requireCenterAdmin(centerId);
   await mergeTag(sourceId, targetId);
   revalidatePath("/admin/tags", "layout");
+  refresh();
 }

--- a/apps/web/src/app/admin/users/_components/GrantRoleDialog.tsx
+++ b/apps/web/src/app/admin/users/_components/GrantRoleDialog.tsx
@@ -87,8 +87,9 @@ export function GrantRoleDialog({
     setIsPending(true);
     try {
       await grantRoleAction(userId, role as GrantableRole, resolvedCenterId);
+      onOpenChange(false);
     } finally {
-      window.location.reload();
+      setIsPending(false);
     }
   }
 

--- a/apps/web/src/app/admin/users/_components/RevokeRoleButton.tsx
+++ b/apps/web/src/app/admin/users/_components/RevokeRoleButton.tsx
@@ -31,8 +31,9 @@ export function RevokeRoleButton({ roleId, label }: Props) {
     setIsPending(true);
     try {
       await revokeRoleAction(roleId);
+      setOpen(false);
     } finally {
-      window.location.reload();
+      setIsPending(false);
     }
   }
 

--- a/apps/web/src/app/admin/users/actions.ts
+++ b/apps/web/src/app/admin/users/actions.ts
@@ -5,7 +5,7 @@
 
 import { auth } from "@/auth";
 import { grantRole, revokeRole, getRoleById } from "@lfstats/db";
-import { revalidatePath } from "next/cache";
+import { refresh, revalidatePath } from "next/cache";
 
 type GrantableRole = "superAdmin" | "admin" | "centerAdmin" | "uploader";
 
@@ -52,6 +52,7 @@ export async function grantRoleAction(
 
   await grantRole(userId, role, centerId);
   revalidatePath("/admin/users");
+  refresh();
 }
 
 export async function revokeRoleAction(roleId: string): Promise<void> {
@@ -85,4 +86,5 @@ export async function revokeRoleAction(roleId: string): Promise<void> {
 
   await revokeRole(roleId);
   revalidatePath("/admin/users");
+  refresh();
 }

--- a/apps/web/src/app/games/[slug]/actions.ts
+++ b/apps/web/src/app/games/[slug]/actions.ts
@@ -68,18 +68,21 @@ export async function toggleExcludeAction(gameId: string, exclude: boolean) {
   await requireCenterAdmin(gameId);
   await setGameExcluded(gameId, exclude);
   await revalidateGame(gameId);
+  refresh();
 }
 
 export async function markGameAsReplayAction(gameId: string) {
   await requireCenterAdmin(gameId);
   await markGameAsReplay(gameId);
   await revalidateGame(gameId);
+  refresh();
 }
 
 export async function markGameAsAbortedAction(gameId: string) {
   await requireCenterAdmin(gameId);
   await markGameAsAborted(gameId);
   await revalidateGame(gameId);
+  refresh();
 }
 
 export async function assignTagAction(gameId: string, tagId: string) {
@@ -117,12 +120,14 @@ export async function addGameToCompetitionAction(
   await requireCenterAdmin(gameId);
   await setGameCompetition(gameId, competitionId);
   await revalidateGame(gameId);
+  refresh();
 }
 
 export async function removeGameFromCompetitionAction(gameId: string): Promise<void> {
   await requireCenterAdmin(gameId);
   await removeGameFromCompetition(gameId);
   await revalidateGame(gameId);
+  refresh();
 }
 
 export async function assignGameToMatchAction(
@@ -135,6 +140,7 @@ export async function assignGameToMatchAction(
   await requireCenterAdmin(gameId);
   await assignGameToMatch(matchId, gameId, gameNumber, team1GameTeamId, team2GameTeamId);
   await revalidateGame(gameId);
+  refresh();
 }
 
 export async function removeGameFromMatchAction(
@@ -144,6 +150,7 @@ export async function removeGameFromMatchAction(
   await requireCenterAdmin(gameId);
   await removeGameFromMatch(matchGameId);
   await revalidateGame(gameId);
+  refresh();
 }
 
 export async function addPenaltyAction(
@@ -162,6 +169,7 @@ export async function addPenaltyAction(
     inGame: false,
   });
   await revalidateGame(gameId);
+  refresh();
 }
 
 export async function updatePenaltyAction(
@@ -177,6 +185,7 @@ export async function updatePenaltyAction(
     mvpValue: parseFloat((formData.get("mvpValue") as string) || "0"),
   });
   await revalidateGame(gameId);
+  refresh();
 }
 
 export async function rescindPenaltyAction(
@@ -187,12 +196,14 @@ export async function rescindPenaltyAction(
   await requireCenterAdmin(gameId);
   await updatePenalty(penaltyId, { rescinded });
   await revalidateGame(gameId);
+  refresh();
 }
 
 export async function deletePenaltyAction(gameId: string, penaltyId: string): Promise<void> {
   await requireCenterAdmin(gameId);
   await deletePenalty(penaltyId);
   await revalidateGame(gameId);
+  refresh();
 }
 
 export async function addTeamPenaltyAction(
@@ -210,6 +221,7 @@ export async function addTeamPenaltyAction(
     inGame: false,
   });
   await revalidateGame(gameId);
+  refresh();
 }
 
 export async function updateTeamPenaltyAction(
@@ -224,6 +236,7 @@ export async function updateTeamPenaltyAction(
     scoreValue: parseInt((formData.get("scoreValue") as string) || "0", 10),
   });
   await revalidateGame(gameId);
+  refresh();
 }
 
 export async function rescindTeamPenaltyAction(
@@ -234,12 +247,14 @@ export async function rescindTeamPenaltyAction(
   await requireCenterAdmin(gameId);
   await updateTeamPenalty(penaltyId, { rescinded });
   await revalidateGame(gameId);
+  refresh();
 }
 
 export async function deleteTeamPenaltyAction(gameId: string, penaltyId: string): Promise<void> {
   await requireCenterAdmin(gameId);
   await deleteTeamPenalty(penaltyId);
   await revalidateGame(gameId);
+  refresh();
 }
 
 export async function setScorecardMercenaryAction(
@@ -250,6 +265,7 @@ export async function setScorecardMercenaryAction(
   await requireCenterAdmin(gameId);
   await setScorecardMercenary(scorecardId, isMercenary);
   await revalidateGame(gameId);
+  refresh();
 }
 
 export async function addGameVideoAction(gameId: string, formData: FormData): Promise<void> {
@@ -275,6 +291,7 @@ export async function addGameVideoAction(gameId: string, formData: FormData): Pr
     { overwrite: true },
   );
   await revalidateGame(gameId);
+  refresh();
 }
 
 /**
@@ -300,6 +317,7 @@ export async function removeGameVideoAction(gameId: string, videoId: string): Pr
   await requireVideoAdmin(videoId);
   await removeGameVideo(videoId);
   await revalidateGame(gameId);
+  refresh();
 }
 
 export async function updateGameVideoAction(
@@ -331,6 +349,7 @@ export async function updateGameVideoAction(
   }
 
   await revalidateGame(gameId);
+  refresh();
   return { ok: true };
 }
 

--- a/apps/web/src/app/laserball/games/[slug]/actions.ts
+++ b/apps/web/src/app/laserball/games/[slug]/actions.ts
@@ -22,7 +22,7 @@ import {
   type LbMatchOvertimePairing,
   type LbMatchTeamPairing,
 } from "@lfstats/db";
-import { revalidatePath } from "next/cache";
+import { refresh, revalidatePath } from "next/cache";
 
 async function requireCenterAdmin(gameId: string) {
   const session = await auth();
@@ -57,6 +57,7 @@ export async function toggleExcludeAction(gameId: string, exclude: boolean) {
   await requireCenterAdmin(gameId);
   await setGameExcluded(gameId, exclude);
   await revalidateLbGame(gameId);
+  refresh();
 }
 
 export async function linkLbMatchAction(
@@ -68,6 +69,7 @@ export async function linkLbMatchAction(
   await linkLbMatch(gameId, otherGameId, pairing, session.user.email ?? undefined);
   await revalidateLbGame(gameId);
   await revalidateLbGame(otherGameId);
+  refresh();
 }
 
 export async function unlinkLbMatchAction(
@@ -84,6 +86,7 @@ export async function unlinkLbMatchAction(
     await revalidateLbGame(gameId);
     await revalidateLbGame(otherGameId);
   }
+  refresh();
 }
 
 export async function addLbMatchOvertimeAction(
@@ -95,12 +98,14 @@ export async function addLbMatchOvertimeAction(
   await requireCenterAdmin(gameId);
   await addLbMatchOvertimeGame(matchId, otGameId, pairing);
   await revalidateLbMatchGames(matchId);
+  refresh();
 }
 
 export async function removeLbMatchOvertimeAction(gameId: string, matchId: string): Promise<void> {
   await requireCenterAdmin(gameId);
   await removeLbMatchOvertimeGame(matchId);
   await revalidateLbMatchGames(matchId);
+  refresh();
 }
 
 // The Videos tab unions videos across every game in a match, so a change to one
@@ -137,6 +142,7 @@ export async function addLbGameVideoAction(gameId: string, formData: FormData): 
     { overwrite: true },
   );
   await revalidateLbGameAndMatch(gameId);
+  refresh();
 }
 
 /**
@@ -163,6 +169,7 @@ export async function removeLbGameVideoAction(gameId: string, videoId: string): 
   await requireVideoAdmin(videoId);
   await removeGameVideo(videoId);
   await revalidateLbGameAndMatch(gameId);
+  refresh();
 }
 
 export async function updateLbGameVideoAction(
@@ -194,5 +201,6 @@ export async function updateLbGameVideoAction(
   }
 
   await revalidateLbGameAndMatch(gameId);
+  refresh();
   return { ok: true };
 }

--- a/apps/web/src/components/admin/CenterEditForm.tsx
+++ b/apps/web/src/components/admin/CenterEditForm.tsx
@@ -24,7 +24,7 @@ export function CenterEditForm({ center, updateAction }: Props) {
     try {
       await updateAction(center.id, formData);
     } finally {
-      window.location.reload();
+      setIsPending(false);
     }
   }
 

--- a/apps/web/src/components/admin/MergeTagDialog.tsx
+++ b/apps/web/src/components/admin/MergeTagDialog.tsx
@@ -50,8 +50,10 @@ export function MergeTagDialog({
     setIsPending(true);
     try {
       await action(sourceTag.id, targetId, centerId);
+      setTargetId("");
+      onOpenChange(false);
     } finally {
-      window.location.reload();
+      setIsPending(false);
     }
   }
 

--- a/apps/web/src/components/admin/TagForm.tsx
+++ b/apps/web/src/components/admin/TagForm.tsx
@@ -38,8 +38,9 @@ export function TagForm({ centerId, tag, open, onOpenChange, createAction, updat
       } else {
         await createAction(centerId, formData);
       }
+      onOpenChange(false);
     } finally {
-      window.location.reload();
+      setIsPending(false);
     }
   }
 

--- a/apps/web/src/components/admin/TagsTable.tsx
+++ b/apps/web/src/components/admin/TagsTable.tsx
@@ -146,7 +146,7 @@ export function TagsTable({
                               await archiveAction(tag.id, centerId);
                             }
                           } finally {
-                            window.location.reload();
+                            setIsPending(false);
                           }
                         }}
                         disabled={isPending}
@@ -217,8 +217,9 @@ export function TagsTable({
                   setIsPending(true);
                   try {
                     await deleteAction(deleteTarget.id, centerId);
+                    setDeleteTarget(undefined);
                   } finally {
-                    window.location.reload();
+                    setIsPending(false);
                   }
                 }}
                 disabled={isPending}

--- a/apps/web/src/components/admin/competition/CompetitionMatchForm.tsx
+++ b/apps/web/src/components/admin/competition/CompetitionMatchForm.tsx
@@ -55,8 +55,11 @@ export function CompetitionMatchForm({
     setIsPending(true);
     try {
       await action(roundId, formData);
+      setTeam1Id("tbd");
+      setTeam2Id("tbd");
+      setPoolId(pools && pools.length > 0 ? pools[0].id : "none");
     } finally {
-      window.location.reload();
+      setIsPending(false);
     }
   }
 

--- a/apps/web/src/components/admin/competition/CompetitionRoundForm.tsx
+++ b/apps/web/src/components/admin/competition/CompetitionRoundForm.tsx
@@ -26,13 +26,16 @@ export function CompetitionRoundForm({ nextRoundNumber, action }: Props) {
 
   async function handleSubmit(e: React.SubmitEvent<HTMLFormElement>) {
     e.preventDefault();
-    const formData = new FormData(e.currentTarget);
+    const form = e.currentTarget;
+    const formData = new FormData(form);
     formData.set("type", type);
     setIsPending(true);
     try {
       await action(formData);
+      form.reset();
+      setType("pool");
     } finally {
-      window.location.reload();
+      setIsPending(false);
     }
   }
 

--- a/apps/web/src/components/admin/competition/CompetitionTeamForm.tsx
+++ b/apps/web/src/components/admin/competition/CompetitionTeamForm.tsx
@@ -6,7 +6,7 @@
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 type Props = {
   action: (formData: FormData) => Promise<void>;
@@ -14,6 +14,7 @@ type Props = {
 
 export function CompetitionTeamForm({ action }: Props) {
   const [isPending, setIsPending] = useState(false);
+  const formRef = useRef<HTMLFormElement>(null);
 
   async function handleSubmit(e: React.SubmitEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -21,13 +22,14 @@ export function CompetitionTeamForm({ action }: Props) {
     setIsPending(true);
     try {
       await action(formData);
+      formRef.current?.reset();
     } finally {
-      window.location.reload();
+      setIsPending(false);
     }
   }
 
   return (
-    <form onSubmit={handleSubmit} className="flex items-end gap-3">
+    <form ref={formRef} onSubmit={handleSubmit} className="flex items-end gap-3">
       <div className="space-y-1">
         <Label htmlFor="name">Team Name</Label>
         <Input id="name" name="name" required placeholder="e.g. Team Alpha" className="w-48" />

--- a/apps/web/src/components/admin/competition/DeleteEntityButton.tsx
+++ b/apps/web/src/components/admin/competition/DeleteEntityButton.tsx
@@ -63,7 +63,8 @@ export function DeleteEntityButton({
       setIsPending(false);
       return;
     }
-    window.location.reload();
+    setIsPending(false);
+    setOpen(false);
   }
 
   return (

--- a/apps/web/src/components/admin/competition/EditMatchScheduleForm.tsx
+++ b/apps/web/src/components/admin/competition/EditMatchScheduleForm.tsx
@@ -58,7 +58,7 @@ export function EditMatchScheduleForm({
     try {
       await action(formData);
     } finally {
-      window.location.reload();
+      setIsPending(false);
     }
   }
 

--- a/apps/web/src/components/admin/competition/EditMatchTeamsForm.tsx
+++ b/apps/web/src/components/admin/competition/EditMatchTeamsForm.tsx
@@ -36,7 +36,7 @@ export function EditMatchTeamsForm({ teams, initialTeam1Id, initialTeam2Id, acti
     try {
       await action(formData);
     } finally {
-      window.location.reload();
+      setIsPending(false);
     }
   }
 

--- a/apps/web/src/components/admin/competition/EditRoundForm.tsx
+++ b/apps/web/src/components/admin/competition/EditRoundForm.tsx
@@ -34,7 +34,7 @@ export function EditRoundForm({ initialName, initialRoundNumber, initialType, ac
     try {
       await action(formData);
     } finally {
-      window.location.reload();
+      setIsPending(false);
     }
   }
 

--- a/apps/web/src/components/admin/competition/GeneratePoolMatchesButton.tsx
+++ b/apps/web/src/components/admin/competition/GeneratePoolMatchesButton.tsx
@@ -18,7 +18,7 @@ export function GeneratePoolMatchesButton({ action }: Props) {
     try {
       await action();
     } finally {
-      window.location.reload();
+      setIsPending(false);
     }
   }
 

--- a/apps/web/src/components/admin/competition/MatchGameAssignForm.tsx
+++ b/apps/web/src/components/admin/competition/MatchGameAssignForm.tsx
@@ -56,8 +56,12 @@ export function MatchGameAssignForm({
     setIsPending(true);
     try {
       await action(formData);
+      setGameNumber("");
+      setGameId("");
+      setTeam1GameTeamId("");
+      setTeam2GameTeamId("");
     } finally {
-      window.location.reload();
+      setIsPending(false);
     }
   }
 

--- a/apps/web/src/components/admin/competition/PoolManager.tsx
+++ b/apps/web/src/components/admin/competition/PoolManager.tsx
@@ -37,12 +37,14 @@ function AddPoolForm({ action }: { action: (formData: FormData) => Promise<void>
 
   async function handleSubmit(e: React.SubmitEvent<HTMLFormElement>) {
     e.preventDefault();
-    const formData = new FormData(e.currentTarget);
+    const form = e.currentTarget;
+    const formData = new FormData(form);
     setIsPending(true);
     try {
       await action(formData);
+      form.reset();
     } finally {
-      window.location.reload();
+      setIsPending(false);
     }
   }
 
@@ -76,8 +78,9 @@ function RenamePoolForm({
     setIsPending(true);
     try {
       await action(pool.id, formData);
+      onCancel();
     } finally {
-      window.location.reload();
+      setIsPending(false);
     }
   }
 

--- a/apps/web/src/components/admin/competition/SortableMatchList.tsx
+++ b/apps/web/src/components/admin/competition/SortableMatchList.tsx
@@ -78,8 +78,9 @@ function EditMatchTeamsForm({
     setIsPending(true);
     try {
       await updateTeamsAction(match.id, formData);
+      onCancel();
     } finally {
-      window.location.reload();
+      setIsPending(false);
     }
   }
 

--- a/apps/web/src/components/games/ExcludeToggleButton.tsx
+++ b/apps/web/src/components/games/ExcludeToggleButton.tsx
@@ -31,8 +31,9 @@ export function ExcludeToggleButton({ gameId, excluded, action }: Props) {
     setIsPending(true);
     try {
       await action(gameId, !excluded);
+      setOpen(false);
     } finally {
-      window.location.reload();
+      setIsPending(false);
     }
   }
 

--- a/apps/web/src/components/games/GameCompetitionManager.tsx
+++ b/apps/web/src/components/games/GameCompetitionManager.tsx
@@ -81,8 +81,9 @@ export function GameCompetitionManager({
     setIsPending(true);
     try {
       await addToCompetitionAction(gameId, selectedCompetitionId);
+      setSelectedCompetitionId("");
     } finally {
-      window.location.reload();
+      setIsPending(false);
     }
   }
 
@@ -90,8 +91,13 @@ export function GameCompetitionManager({
     setIsPending(true);
     try {
       await removeFromCompetitionAction(gameId);
+      setSelectedCompetitionId("");
+      setSelectedMatchId("");
+      setSelectedGameNumber("");
+      setTeam1GameTeamId("");
+      setTeam2GameTeamId("");
     } finally {
-      window.location.reload();
+      setIsPending(false);
     }
   }
 
@@ -106,8 +112,12 @@ export function GameCompetitionManager({
         team1GameTeamId,
         team2GameTeamId,
       );
+      setSelectedMatchId("");
+      setSelectedGameNumber("");
+      setTeam1GameTeamId("");
+      setTeam2GameTeamId("");
     } finally {
-      window.location.reload();
+      setIsPending(false);
     }
   }
 
@@ -116,8 +126,12 @@ export function GameCompetitionManager({
     setIsPending(true);
     try {
       await removeFromMatchAction(gameId, matchAssignment.matchGameId);
+      setSelectedMatchId("");
+      setSelectedGameNumber("");
+      setTeam1GameTeamId("");
+      setTeam2GameTeamId("");
     } finally {
-      window.location.reload();
+      setIsPending(false);
     }
   }
 

--- a/apps/web/src/components/games/MarkAbortedButton.tsx
+++ b/apps/web/src/components/games/MarkAbortedButton.tsx
@@ -39,8 +39,9 @@ export function MarkAbortedButton({ gameId, isAborted, action }: Props) {
     setIsPending(true);
     try {
       await action(gameId);
+      setOpen(false);
     } finally {
-      window.location.reload();
+      setIsPending(false);
     }
   }
 

--- a/apps/web/src/components/games/MarkReplayButton.tsx
+++ b/apps/web/src/components/games/MarkReplayButton.tsx
@@ -39,8 +39,9 @@ export function MarkReplayButton({ gameId, isReplay, action }: Props) {
     setIsPending(true);
     try {
       await action(gameId);
+      setOpen(false);
     } finally {
-      window.location.reload();
+      setIsPending(false);
     }
   }
 

--- a/apps/web/src/components/games/PenaltyManager.tsx
+++ b/apps/web/src/components/games/PenaltyManager.tsx
@@ -33,8 +33,9 @@ export function PenaltyManager({ gameId, scorecardId, penalties, canEdit, action
     setIsPending(true);
     try {
       await actions.addAction(gameId, scorecardId, formData);
+      setShowAdd(false);
     } finally {
-      window.location.reload();
+      setIsPending(false);
     }
   }
 
@@ -42,8 +43,9 @@ export function PenaltyManager({ gameId, scorecardId, penalties, canEdit, action
     setIsPending(true);
     try {
       await actions.updateAction(gameId, penaltyId, formData);
+      setEditingId(null);
     } finally {
-      window.location.reload();
+      setIsPending(false);
     }
   }
 
@@ -52,7 +54,7 @@ export function PenaltyManager({ gameId, scorecardId, penalties, canEdit, action
     try {
       await actions.rescindAction(gameId, penaltyId, rescinded);
     } finally {
-      window.location.reload();
+      setIsPending(false);
     }
   }
 
@@ -61,7 +63,7 @@ export function PenaltyManager({ gameId, scorecardId, penalties, canEdit, action
     try {
       await actions.deleteAction(gameId, penaltyId);
     } finally {
-      window.location.reload();
+      setIsPending(false);
     }
   }
 

--- a/apps/web/src/components/games/PlayerStatsSheet.tsx
+++ b/apps/web/src/components/games/PlayerStatsSheet.tsx
@@ -100,7 +100,7 @@ export function PlayerStatsSheet({
                         try {
                           await mercenaryAction(player.id, !player.isMercenary);
                         } finally {
-                          window.location.reload();
+                          setIsMercPending(false);
                         }
                       }}
                     >

--- a/apps/web/src/components/games/TeamPenaltyManager.tsx
+++ b/apps/web/src/components/games/TeamPenaltyManager.tsx
@@ -33,8 +33,9 @@ export function TeamPenaltyManager({ gameId, gameTeamId, penalties, canEdit, act
     setIsPending(true);
     try {
       await actions.addAction(gameId, gameTeamId, formData);
+      setShowAdd(false);
     } finally {
-      window.location.reload();
+      setIsPending(false);
     }
   }
 
@@ -42,8 +43,9 @@ export function TeamPenaltyManager({ gameId, gameTeamId, penalties, canEdit, act
     setIsPending(true);
     try {
       await actions.updateAction(gameId, penaltyId, formData);
+      setEditingId(null);
     } finally {
-      window.location.reload();
+      setIsPending(false);
     }
   }
 
@@ -52,7 +54,7 @@ export function TeamPenaltyManager({ gameId, gameTeamId, penalties, canEdit, act
     try {
       await actions.rescindAction(gameId, penaltyId, rescinded);
     } finally {
-      window.location.reload();
+      setIsPending(false);
     }
   }
 
@@ -61,7 +63,7 @@ export function TeamPenaltyManager({ gameId, gameTeamId, penalties, canEdit, act
     try {
       await actions.deleteAction(gameId, penaltyId);
     } finally {
-      window.location.reload();
+      setIsPending(false);
     }
   }
 

--- a/apps/web/src/components/games/VideoManager.tsx
+++ b/apps/web/src/components/games/VideoManager.tsx
@@ -134,7 +134,7 @@ export function VideoManager({
     setIsPending(true);
 
     // Editing can fail on a recoverable conflict, so it keeps the dialog open
-    // and shows why instead of reloading past the error.
+    // and shows why instead of resetting past the error.
     if (dialogMode === "edit" && editing) {
       const result = await updateAction(gameId, editing.id, formData);
       if (!result.ok) {
@@ -142,14 +142,26 @@ export function VideoManager({
         setIsPending(false);
         return;
       }
-      window.location.reload();
+      setDialogMode(null);
+      setEditing(null);
+      setUrl("");
+      setLabel("");
+      setPlayerId("");
+      setError(null);
+      setIsPending(false);
       return;
     }
 
     try {
       await addAction(gameId, formData);
+      setDialogMode(null);
+      setEditing(null);
+      setUrl("");
+      setLabel("");
+      setPlayerId("");
+      setError(null);
     } finally {
-      window.location.reload();
+      setIsPending(false);
     }
   }
 
@@ -157,8 +169,9 @@ export function VideoManager({
     setIsPending(true);
     try {
       await removeAction(gameId, videoId);
+      setDeleteTarget(null);
     } finally {
-      window.location.reload();
+      setIsPending(false);
     }
   }
 

--- a/apps/web/src/components/laserball/LbMatchManager.tsx
+++ b/apps/web/src/components/laserball/LbMatchManager.tsx
@@ -107,8 +107,11 @@ export function LbMatchManager({
         otherSide1TeamId,
         otherSide2TeamId: otherSide2.id,
       });
+      setSelectedCandidateId("");
+      setGameSide1TeamId("");
+      setOtherSide1TeamId("");
     } finally {
-      window.location.reload();
+      setIsPending(false);
     }
   }
 
@@ -118,8 +121,13 @@ export function LbMatchManager({
     setIsPending(true);
     try {
       await unlinkAction(gameId, matchDetail.id, otherGameId);
+      setSelectedCandidateId("");
+      setGameSide1TeamId("");
+      setOtherSide1TeamId("");
+      setSelectedOtCandidateId("");
+      setOtSide1TeamId("");
     } finally {
-      window.location.reload();
+      setIsPending(false);
     }
   }
 
@@ -134,8 +142,10 @@ export function LbMatchManager({
         side1TeamId: otSide1TeamId,
         side2TeamId: otSide2.id,
       });
+      setSelectedOtCandidateId("");
+      setOtSide1TeamId("");
     } finally {
-      window.location.reload();
+      setIsPending(false);
     }
   }
 
@@ -144,8 +154,10 @@ export function LbMatchManager({
     setIsPending(true);
     try {
       await removeOvertimeAction(gameId, matchDetail.id);
+      setSelectedOtCandidateId("");
+      setOtSide1TeamId("");
     } finally {
-      window.location.reload();
+      setIsPending(false);
     }
   }
 


### PR DESCRIPTION
## Summary
- Completes the `refresh()` (next/cache) rollout described in `docs/TODO.md`: all 29 `window.location.reload()` sites across `apps/web/src` now call `refresh()` from inside their server action (after `revalidatePath`) instead of forcing a full page reload from the client — including `DeleteEntityButton.tsx`, the shared component originally left out of the first pass.
- Each server action's `revalidatePath` logic was left untouched — only `refresh()` was added.
- Each migrated client component had its `finally { window.location.reload() }` replaced with `setIsPending(false)`, plus explicit resets for whatever local state (dialog `open`, create-form fields, selection dropdowns) the reload used to clear for free.
- `DeleteEntityButton.tsx` (shared across 7 admin pages) now closes its `AlertDialog` and resets `isPending` on success instead of reloading. Four of its backing actions (`deleteCompetitionTeamAction`, `removePlayerFromTeamAction`, `deleteRoundAction`, `removeGameAction`) hadn't received `refresh()` in the earlier per-route passes since they weren't in scope there — added it to all four. The other three callers (`deleteMatchAction`, `deletePoolAction`, `removeGameFromCompetitionAction`) already had it.
- Also added the previously-missing `refresh()` call to `createApiKeyAction`, which the initial reload-removal pass on `ApiKeysClient.tsx` otherwise would have left with no refresh signal after dismissing the "here's your key" dialog.
- Promoted `refresh()` to the canonical Pattern B example in `apps/web/CLAUDE.md`, now that the trial has held up and the rollout is complete.

## Test plan
- [x] `pnpm typecheck` passes across all 3 packages
- [x] `pnpm --filter web lint` passes clean
- [ ] Manual browser verification per site (repeated clicks, slow network) watching for the `isPending`-stuck scheduler bug the reload pattern originally guarded against (vercel/next.js#88767, #77504, #86055, #82289) — no automated repro exists for this, per `docs/TODO.md`'s migration checklist. Left as draft until this pass is done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)